### PR TITLE
Limit Dependabot to just github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,18 @@ updates:
     schedule:
       interval: daily
 
-  - package-ecosystem: npm
-    directory: /backend
-    schedule:
-      interval: daily
-    commit-message:
-      prefix: "Backend"
-      include: "scope"
+  # - package-ecosystem: npm
+  #   directory: /backend
+  #   schedule:
+  #     interval: daily
+  #   commit-message:
+  #     prefix: "Backend"
+  #     include: "scope"
 
-  - package-ecosystem: npm
-    directory: /frontend
-    schedule:
-      interval: daily
-    commit-message:
-      prefix: "Frontend"
-      include: "scope"
+  # - package-ecosystem: npm
+  #   directory: /frontend
+  #   schedule:
+  #     interval: daily
+  #   commit-message:
+  #     prefix: "Frontend"
+  #     include: "scope"


### PR DESCRIPTION
Dependabot is a little noisy for the MVP stage.  This limits it to just GitHub Actions.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://public-code-57-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/public-code/actions/workflows/merge-main.yml)